### PR TITLE
rename elementRef parentRef

### DIFF
--- a/.changeset/silent-buttons-punch.md
+++ b/.changeset/silent-buttons-punch.md
@@ -1,0 +1,6 @@
+---
+"@cutting/svg": minor
+"@cutting/use-get-parent-size": minor
+---
+
+rename elementRef parentRef

--- a/packages/graphql-explorer/demo/App.tsx
+++ b/packages/graphql-explorer/demo/App.tsx
@@ -9,7 +9,7 @@ export function App(): JSX.Element {
   return (
     <ApplicationLayout heading="@cutting/svg" className={cuttingTheme}>
       <div className={styles.container} ref={ref}>
-        <ParentsizeSVG elementRef={ref} options={{ debounceDelay: 10 }}>
+        <ParentsizeSVG parentRef={ref} options={{ debounceDelay: 10 }}>
           <rect
             x="20%"
             y="20%"

--- a/packages/graphql-explorer/src/containers/Explorer/Explorer.tsx
+++ b/packages/graphql-explorer/src/containers/Explorer/Explorer.tsx
@@ -57,7 +57,7 @@ export function Explorer({ gatewayUrl }: ExplorerProps): JSX.Element {
   return (
     <>
       <div className={styles.container} ref={ref}>
-        <ParentsizeSVG elementRef={ref} align="center">
+        <ParentsizeSVG parentRef={ref} align="center">
           <circle fill="#fff" x={12} y={20} r={200} />
         </ParentsizeSVG>
       </div>

--- a/packages/svg/README.md
+++ b/packages/svg/README.md
@@ -18,7 +18,7 @@ A react component that will resize and scale to the dimensions of the supplied r
 
 ![svg document resizing to scale when using the ParentsizeSVG component](./img/sizer.gif)
 
-The `ParentsizeSVG` component takes an `elementRef` prop that should point to a valid HTML DOM element.
+The `ParentsizeSVG` component takes an `parentRef` prop that should point to a valid HTML DOM element.
 
 ## usage
 

--- a/packages/svg/demo/App.tsx
+++ b/packages/svg/demo/App.tsx
@@ -9,7 +9,7 @@ export function App(): JSX.Element {
   return (
     <ApplicationLayout heading="@cutting/svg" className={cuttingTheme}>
       <div className={styles.container} ref={ref}>
-        <ParentsizeSVG elementRef={ref} options={{ debounceDelay: 10 }}>
+        <ParentsizeSVG parentRef={ref} options={{ debounceDelay: 10 }}>
           <rect
             x="0"
             y="0"

--- a/packages/svg/src/components/ParentsizeSVG/ParentSizeSVG.test.tsx
+++ b/packages/svg/src/components/ParentsizeSVG/ParentSizeSVG.test.tsx
@@ -10,7 +10,7 @@ function TestEr(props: Partial<ParentsizeSVGProps>) {
   useParentSize(ref);
 
   return (
-    <ParentsizeSVG {...props} elementRef={ref}>
+    <ParentsizeSVG {...props} parentRef={ref}>
       <rect x="20%" y="20%" width="200px" height="200px" rx="20" />
     </ParentsizeSVG>
   );

--- a/packages/svg/src/components/ParentsizeSVG/ParentsizeSVG.tsx
+++ b/packages/svg/src/components/ParentsizeSVG/ParentsizeSVG.tsx
@@ -8,7 +8,7 @@ import { ResponsiveSVG } from '../ResponsiveSVG/ResponsiveSVG';
 type Align = 'none' | 'center';
 
 export type ParentsizeSVGProps<E extends HTMLElement = HTMLElement> = {
-  elementRef: RefObject<E>;
+  parentRef: RefObject<E>;
   style?: CSSProperties;
   align?: Align;
   scale?: number;
@@ -25,7 +25,7 @@ export const DefaultStyle: CSSProperties = {
 } as const;
 
 export function ParentsizeSVG<E extends HTMLElement>({
-  elementRef,
+  parentRef,
   children,
   style = DefaultStyle,
   scale = 1,
@@ -33,18 +33,18 @@ export function ParentsizeSVG<E extends HTMLElement>({
   options: { debounceDelay = 50, ...optionsRest } = {},
   ...rest
 }: PropsWithChildren<ParentsizeSVGProps<E>>): JSX.Element | null {
-  const { width, height } = useParentSize(elementRef, { debounceDelay, ...optionsRest });
+  const { width, height } = useParentSize(parentRef, { debounceDelay, ...optionsRest });
 
   useEffect(() => {
-    if (!elementRef.current) {
+    if (!parentRef.current) {
       return;
     }
 
     for (const [key, value] of Object.entries(style)) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      elementRef.current.style[key as any] = value;
+      parentRef.current.style[key as any] = value;
     }
-  }, [elementRef, style]);
+  }, [parentRef, style]);
 
   const transform =
     align === 'center'

--- a/packages/use-get-parent-size/src/useParentSize/useParentSize.ts
+++ b/packages/use-get-parent-size/src/useParentSize/useParentSize.ts
@@ -25,7 +25,7 @@ export const useParentSize = <E extends Element>(
 
   const transformer = useCallback(transformFunc, [transformFunc]);
 
-  assert(!!ref, 'You must pass a valid ref to useParent');
+  assert(!!ref, 'You must pass a valid ref to useParentSize');
 
   const debouncedCallback = useDebouncedCallback(
     (value: Dimensions) => {


### PR DESCRIPTION
## Motivation

Change `elementRef` in `<ParentsizeSVG />` to `parentRef`

## Approach

just do it